### PR TITLE
Fix #1: Improve error on existing file at symlink path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages
 
 setup(
     name="dotstree",
-    version="0.1.0",
+    version="0.1.1",
     description="Flexible dotfile manager based on directory trees.",
     long_description=Path("README.md").read_text(),
     long_description_content_type="text/markdown",

--- a/src/dotstree/lib.py
+++ b/src/dotstree/lib.py
@@ -96,7 +96,7 @@ def combine_spec_trees(paths: List[Path]):
     raise NotImplementedError()
 
 
-def check_symlink(origin: Path, target: Path):
+def symlink_is_correct(origin: Path, target: Path):
     """True iff symlink exists at origin and points to destination."""
 
     if not origin.is_symlink():

--- a/src/dotstree/lib.py
+++ b/src/dotstree/lib.py
@@ -98,12 +98,9 @@ def combine_spec_trees(paths: List[Path]):
 
 def check_symlink(origin: Path, target: Path):
     """True iff symlink exists at origin and points to destination."""
-    if not origin.exists():
-        log.debug(f"{origin} doesn't exist.")
-        return False
 
     if not origin.is_symlink():
-        log.debug(f"{origin} is not a symlink.")
+        log.debug(f"Not a symlink: {origin}")
         return False
 
     # There is a Path.readlink, but unfortunately Python >=3.9 only :(

--- a/src/dotstree/main.py
+++ b/src/dotstree/main.py
@@ -93,10 +93,13 @@ def install_specs(all_specs):
             for ln in spec.get("symlinks"):
                 origin = Path(ln["from"]).expanduser()
                 target = Path(ln["to"])
-                if not check_symlink(Path(origin), Path(target)):
-                    origin.parent.mkdir(parents=True, exist_ok=True)
-                    log.debug(f"Symlinking {origin} to {target}")
-                    origin.symlink_to(target)
+                if check_symlink(Path(origin), Path(target)):
+                    log.debug(f"Skipping {origin} because it already points to {target}")
+                    continue
+
+                origin.parent.mkdir(parents=True, exist_ok=True)
+                log.debug(f"Symlinking {origin} to {target}")
+                origin.symlink_to(target)
 
         if "install" in spec:
             if "check" in spec:

--- a/src/dotstree/main.py
+++ b/src/dotstree/main.py
@@ -18,8 +18,8 @@ from pathlib import Path
 from time import time
 
 from docopt import docopt
-from dotstree import log
-from dotstree.lib import load_spec_tree, check_symlink, run_command
+from . import log
+from .lib import load_spec_tree, check_symlink, run_command
 from tabulate import tabulate
 from tqdm import tqdm
 

--- a/src/dotstree/main.py
+++ b/src/dotstree/main.py
@@ -97,6 +97,10 @@ def install_specs(all_specs):
                     log.debug(f"Skipping {origin} because it already points to {target}")
                     continue
 
+                if origin.exists() or origin.is_symlink():
+                    log.error(f"Unexpected file at {origin} - remove it and try again.")
+                    exit(1)
+
                 origin.parent.mkdir(parents=True, exist_ok=True)
                 log.debug(f"Symlinking {origin} to {target}")
                 origin.symlink_to(target)

--- a/src/dotstree/main.py
+++ b/src/dotstree/main.py
@@ -101,7 +101,7 @@ def install_specs(all_specs):
 
                 if origin.exists() or origin.is_symlink():
                     log.error(f"Unexpected file at {origin} - remove it and try again.")
-                    exit(1)
+                    continue
 
                 origin.parent.mkdir(parents=True, exist_ok=True)
                 log.debug(f"Symlinking {origin} to {target}")

--- a/src/dotstree/main.py
+++ b/src/dotstree/main.py
@@ -100,7 +100,6 @@ def install_specs(all_specs):
 
         if "install" in spec:
             if "check" in spec:
-
                 result = run_command("pwd", spec["path"].absolute())
                 print(result.stdout.decode())
 

--- a/src/dotstree/main.py
+++ b/src/dotstree/main.py
@@ -19,7 +19,7 @@ from time import time
 
 from docopt import docopt
 from . import log
-from .lib import load_spec_tree, check_symlink, run_command
+from .lib import load_spec_tree, symlink_is_correct, run_command
 from tabulate import tabulate
 from tqdm import tqdm
 
@@ -57,7 +57,7 @@ def check_specs(all_specs):
             for ln in spec.get("symlinks"):
                 origin = Path(ln["from"]).expanduser()
                 target = Path(ln["to"])
-                if not check_symlink(Path(origin), Path(target)):
+                if not symlink_is_correct(Path(origin), Path(target)):
                     res["Symlinks"] = "🔴"
 
         t2 = time()
@@ -93,7 +93,7 @@ def install_specs(all_specs):
             for ln in spec.get("symlinks"):
                 origin = Path(ln["from"]).expanduser()
                 target = Path(ln["to"])
-                if check_symlink(Path(origin), Path(target)):
+                if symlink_is_correct(Path(origin), Path(target)):
                     log.debug(f"Skipping {origin} because it already points to {target}")
                     continue
 

--- a/src/dotstree/main.py
+++ b/src/dotstree/main.py
@@ -94,7 +94,9 @@ def install_specs(all_specs):
                 origin = Path(ln["from"]).expanduser()
                 target = Path(ln["to"])
                 if symlink_is_correct(Path(origin), Path(target)):
-                    log.debug(f"Skipping {origin} because it already points to {target}")
+                    log.debug(
+                        f"Skipping {origin} because it already points to {target}"
+                    )
                     continue
 
                 if origin.exists() or origin.is_symlink():

--- a/yaghm.yaml
+++ b/yaghm.yaml
@@ -1,0 +1,9 @@
+# Git hook spec for use with https://github.com/metov/yaghm
+pre-commit:
+  # Enforce code style
+  - enable: black --check .
+    install: pip install black
+
+  # Require incrementing version in feature branches
+  - enable: require_version_bump master setup.py
+    install: pip install metovhooks


### PR DESCRIPTION
If you try to install symlinks when a file already exists at where the symlink would be, you will get a crash: Symlink creation will fail with `FileExistsError` (#1). This PR adds a better error message instead of an ugly and confusing stack trace.

At some point, it would be nice if dotstree could fix existing incorrect symlinks (#3) and moce existing config files out of the way (#4). For now, I think just printing an error is a reasonably safe behavior.
